### PR TITLE
fix: Modified the "Increment" button code so that the slider value is capped at 10.0.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -59,9 +59,20 @@ impl epi::App for TemplateApp {
                 ui.text_edit_singleline(label);
             });
 
-            ui.add(egui::Slider::f32(value, 0.0..=10.0).text("value"));
-            if ui.button("Increment").clicked {
-                *value += 1.0;
+            const MAX_SLIDER_VALUE: f32 = 10.0;
+            ui.add(egui::Slider::f32(value, 0.0..=MAX_SLIDER_VALUE).text("value"));
+
+            let mut button = egui::widgets::Button::new("Increment");
+            if *value >= MAX_SLIDER_VALUE {
+                button = button.enabled(false);
+            }
+
+            if ui.add(button).clicked {
+                if *value + 1.0 > MAX_SLIDER_VALUE {
+                    *value = MAX_SLIDER_VALUE;
+                } else {
+                    *value += 1.0;
+                }
             }
 
             ui.with_layout(egui::Layout::bottom_up(egui::Align::Center), |ui| {


### PR DESCRIPTION
The original code had a bug in it where if you clicked the increment button enough it would increase the value beyond the maximum that the slider was able to represent. This commit makes a modification so that the maximum value that the slider can ever achieve is 10.0 (same as the original code), regardless of how many times you click the increment button.  In addition, once you reach the maximum the button is disabled, which makes it obvious that you can't go past 10.0.