### PR TITLE
Add dev library

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Make sure you are using the latest version of stable rust.
 
 `cargo run --release`
 
-On Linux you need to first run `sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev`.
+On Linux you need to first run `sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev`.
 
 ### Compiling for the web
 


### PR DESCRIPTION
Following the quick start instructions I got a compiler error because my freshly installed Ubuntu 20.04 LTS machine did not come with this library preinstalled. I figured that is a common enough target that it should be added to the documentation.

Thank you for this awesome project!